### PR TITLE
fix bug - only printing 1 char with ide1.6.7

### DIFF
--- a/LiquidCrystal_I2C.cpp
+++ b/LiquidCrystal_I2C.cpp
@@ -252,7 +252,7 @@ inline void LiquidCrystal_I2C::command(uint8_t value) {
 
 inline size_t LiquidCrystal_I2C::write(uint8_t value) {
 	send(value, Rs);
-	return 0;
+	return 1; // 1 = true
 }
 
 


### PR DESCRIPTION
return must be true
